### PR TITLE
Add diffuse and direct irradiation and correct general term solarRadiation

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -49,3 +49,10 @@ contributors:
   project: 
   comments: 
   year: 2022
+- name: Miadowicz
+  surname: Inga
+  mail: Inga.Miadowicz@dlr.de
+  organization: German Aerospace Center (DLR)
+  project: 
+  comments: 
+  year: 2023

--- a/WeatherObserved/ADOPTERS.yaml
+++ b/WeatherObserved/ADOPTERS.yaml
@@ -16,3 +16,12 @@ currentAdopters:
  project: https://lasrozasinnova.es/cosmos-plataforma-de-ciudad-inteligente-de-las-rozas/
  comments:
  startDate: 1-1-2022
+ -
+ adopter: Inga Miadowicz
+ description:
+ mail: Inga.Miadowicz@dlr.de
+ organization: German Aerospace Center (DLR)
+ project: 
+ comments: Add fields direct and diffuseIrradiation
+ startDate: 3-29-2023
+

--- a/WeatherObserved/schema.json
+++ b/WeatherObserved/schema.json
@@ -39,10 +39,20 @@
           "minimum": 0,
           "description": "Property. Model:'https://schema.org/Number'. Amount of water rain registered. Units:'Liters per square meter'. "
         },
-        "solarRadiation": {
+        "solarIrradiation": {
           "type": "number",
           "minimum": 0,
-          "description": "Property. Model:'https://schema.org/Number'. The solar radiation observed measured in Watts per square. Units:'w/m2'"
+          "description": "Property. Model:'https://schema.org/Number'. The solar or global radiation observed as sum of diffuse and direct irradiance reaching the same surface. Units:'w/m2'"
+        },
+        "directIrradiation": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Property. Model:'https://schema.org/Number'. Direct irradiance is the part of the solar irradiance that directly reaches a surface. Units:'w/m2'"
+        },
+        "diffuseIrradiation": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Property. Model:'https://schema.org/Number'. Diffuse irradiance is the part of the solar irradiance that is scattered by the atmosphere. Units:'w/m2'"
         },
         "pressureTendency": {
           "oneOf": [

--- a/WeatherObserved/schema.json
+++ b/WeatherObserved/schema.json
@@ -39,10 +39,10 @@
           "minimum": 0,
           "description": "Property. Model:'https://schema.org/Number'. Amount of water rain registered. Units:'Liters per square meter'. "
         },
-        "solarIrradiation": {
+        "solarRadiation": {
           "type": "number",
           "minimum": 0,
-          "description": "Property. Model:'https://schema.org/Number'. The solar or global radiation observed as sum of diffuse and direct irradiance reaching the same surface. Units:'w/m2'"
+          "description": "Property. Model:'https://schema.org/Number'. The solar radiation observed measured in Watts per square. Units:'w/m2'"
         },
         "directIrradiation": {
           "type": "number",


### PR DESCRIPTION
We have a weather station at our plant that measures weather observed. So far the FIWARE Smart Data Model WeatherObserved meets our data model besides the measures for radiation or irradiation.

Actually the model only contains solarRadiation measured in Watts per square. Our weather station differentiates between:
- Direct Irradiation: The direct radiation that reaches the earth's surface unimpeded by the direct path
- Diffuse Irradiation: The diffuse radiation that is scattered by the components of the atmosphere, e.g. clouds and dust
- Global irradiation: The sum of direct and diffuse radiation, or total solar irradiation

I think the measurement solarRadiation could mean global irradiation or overall irradiation. Therefore I'd like to:
1) extend the model with two further numbers for diffuse / direct irradiation
2) rename the variable solarRadiation to solarIrradiation (as this is what is being measured https://en.wikipedia.org/wiki/Solar_irradiance) or even globalIrradiation to describe exactly what is being measured here.

I look forward to discuss the changes and extension 😀 
